### PR TITLE
Upgrade from sixtyfps to slint UI framework

### DIFF
--- a/rust/examples/kde_dolphin/Cargo.toml
+++ b/rust/examples/kde_dolphin/Cargo.toml
@@ -9,10 +9,10 @@ build = "build.rs"
 publish = false
 
 [dependencies]
-sixtyfps = "0.1"
+slint = "0.2"
 vaas = { path = "../.."}
 tokio = "1"
 structopt = "0.3"
 
 [build-dependencies]
-sixtyfps-build = "0.1"
+slint-build = "0.2"

--- a/rust/examples/kde_dolphin/build.rs
+++ b/rust/examples/kde_dolphin/build.rs
@@ -1,3 +1,3 @@
 fn main() {
-    sixtyfps_build::compile("ui/app.60").unwrap();
+    slint_build::compile("ui/app.slint").unwrap();
 }

--- a/rust/examples/kde_dolphin/src/main.rs
+++ b/rust/examples/kde_dolphin/src/main.rs
@@ -1,17 +1,17 @@
-use sixtyfps::Model;
+use slint::Model;
 use std::{env, path::PathBuf, rc::Rc, time::Duration};
 use structopt::StructOpt;
 use vaas::{CancellationTokenSource, Vaas};
-sixtyfps::include_modules!();
+slint::include_modules!();
 
 #[tokio::main]
 async fn main() {
     let opt = Opt::from_args();
     let file_items = get_files(&opt.files);
-    let file_model = Rc::new(sixtyfps::VecModel::<FileItem>::from(file_items.clone()));
+    let file_model = Rc::new(slint::VecModel::<FileItem>::from(file_items.clone()));
     let ui = Ui::new();
     ui.on_close(move || std::process::exit(0));
-    ui.set_file_model(sixtyfps::ModelHandle::new(file_model));
+    ui.set_file_model(slint::ModelRc::from(file_model));
 
     let handle_weak = ui.as_weak();
     ui.on_scan({
@@ -67,7 +67,7 @@ async fn main() {
     ui.run();
 }
 
-fn update_file_model(handle: sixtyfps::Weak<Ui>, fi: FileItem) {
+fn update_file_model(handle: slint::Weak<Ui>, fi: FileItem) {
     handle.upgrade_in_event_loop(move |handle| {
         let fm = handle.get_file_model();
         fm.set_row_data((fi.id - 1) as usize, fi)

--- a/rust/examples/kde_dolphin/ui/app.slint
+++ b/rust/examples/kde_dolphin/ui/app.slint
@@ -1,4 +1,4 @@
-import { VerticalBox, ListView, HorizontalBox, Button } from "sixtyfps_widgets.60";
+import { VerticalBox, ListView, HorizontalBox, Button } from "std-widgets.slint";
 
 export struct FileItem := {
     id: int,


### PR DESCRIPTION
The UI framework used in the KDE example was renamed from "sixtyfps" to "slint". This PR switches from the old name to the new name, as the Crates under the old name won't receive any update in the future.