### PR TITLE
Improve rust sdk

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -16,13 +16,11 @@ thiserror = "1.0"
 uuid = { version = "0.8", features = ["serde", "v4"] }
 reqwest = "0.11"
 regex = "1.5"
-tokio = { version = "1.9", features = ["full"] }
+tokio = { version = "1.9", features = ["sync", "fs"] }
 sha2 = "0.9.5"
 futures = "0.3"
 rand = "0.8"
 
 [dev-dependencies]
 dotenv = "0.15"
-futures = "0.3"
-warp = "0.3"
-tokio-stream = "0.1.6"
+tokio = { version = "1.9", features = ["rt", "macros"] }

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -23,4 +23,4 @@ rand = "0.8"
 
 [dev-dependencies]
 dotenv = "0.15"
-tokio = { version = "1.9", features = ["rt", "macros"] }
+tokio = { version = "1.9", features = ["rt", "macros", "rt-multi-thread"] }

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -14,7 +14,6 @@ serde = { version = "1.0", features = ["derive"]}
 serde_json = "1.0"
 thiserror = "1.0"
 uuid = { version = "0.8", features = ["serde", "v4"] }
-cancellation = "0.1"
 reqwest = "0.11"
 regex = "1.5"
 tokio = { version = "1.9", features = ["full"] }

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -17,7 +17,6 @@ uuid = { version = "0.8", features = ["serde", "v4"] }
 cancellation = "0.1"
 reqwest = "0.11"
 regex = "1.5"
-flume = "0.10"
 tokio = { version = "1.9", features = ["full"] }
 sha2 = "0.9.5"
 futures = "0.3"

--- a/rust/src/builder.rs
+++ b/rust/src/builder.rs
@@ -85,7 +85,7 @@ impl Default for Builder {
         Self {
             options: Options {
                 poll_delay_ms: 100,
-                keep_alive_delay_ms: 1000,
+                keep_alive_delay_ms: 10_000,
                 keep_alive: true,
             },
             token: String::new(),

--- a/rust/src/builder.rs
+++ b/rust/src/builder.rs
@@ -58,8 +58,7 @@ impl Default for Builder {
         Self {
             poll_delay_ms: 100,
             token: String::new(),
-            url: Url::from_str("wss://gateway-vaas.gdatasecurity.de")
-                .unwrap(),
+            url: Url::from_str("wss://gateway-vaas.gdatasecurity.de").unwrap(),
         }
     }
 }

--- a/rust/src/builder.rs
+++ b/rust/src/builder.rs
@@ -30,16 +30,6 @@ impl Builder {
         }
     }
 
-    /// Set the delay between each poll of the API for results. Defaults to 100ms.
-    pub fn poll_delay_ms(self, delay: u64) -> Self {
-        Self {
-            options: Options {
-                poll_delay_ms: delay,
-                ..self.options
-            },
-            ..self
-        }
-    }
     /// Set the delay in which a Ping is sent to the server to keep the connection alive.
     /// Defaults to 10s.
     pub fn keep_alive_delay_ms(self, delay: u64) -> Self {
@@ -84,7 +74,6 @@ impl Default for Builder {
         use std::str::FromStr;
         Self {
             options: Options {
-                poll_delay_ms: 100,
                 keep_alive_delay_ms: 10_000,
                 keep_alive: true,
             },

--- a/rust/src/builder.rs
+++ b/rust/src/builder.rs
@@ -3,6 +3,7 @@
 use reqwest::Url;
 
 use crate::error::VResult;
+use crate::options::Options;
 use crate::vaas::Vaas;
 
 /// Builder struct to create a new Vaas instance with the expected default values.
@@ -16,8 +17,8 @@ use crate::vaas::Vaas;
 /// ```
 pub struct Builder {
     token: String,
-    poll_delay_ms: u64,
     url: Url,
+    options: Options,
 }
 
 impl Builder {
@@ -32,7 +33,33 @@ impl Builder {
     /// Set the delay between each poll of the API for results. Defaults to 100ms.
     pub fn poll_delay_ms(self, delay: u64) -> Self {
         Self {
-            poll_delay_ms: delay,
+            options: Options {
+                poll_delay_ms: delay,
+                ..self.options
+            },
+            ..self
+        }
+    }
+    /// Set the delay in which a Ping is sent to the server to keep the connection alive.
+    /// Defaults to 10s.
+    pub fn keep_alive_delay_ms(self, delay: u64) -> Self {
+        Self {
+            options: Options {
+                keep_alive_delay_ms: delay,
+                ..self.options
+            },
+            ..self
+        }
+    }
+
+    /// Enable or disable periodic pings to the server to keep the connection alive.
+    /// Defaults to enabled (true).
+    pub fn keep_alive(self, keep_alive: bool) -> Self {
+        Self {
+            options: Options {
+                keep_alive,
+                ..self.options
+            },
             ..self
         }
     }
@@ -45,7 +72,7 @@ impl Builder {
     /// Create a [Vaas] struct from the `VaasBuilder`.
     pub fn build(self) -> VResult<Vaas> {
         Ok(Vaas {
-            poll_delay_ms: self.poll_delay_ms,
+            options: self.options,
             token: self.token,
             url: self.url,
         })
@@ -56,7 +83,11 @@ impl Default for Builder {
     fn default() -> Self {
         use std::str::FromStr;
         Self {
-            poll_delay_ms: 100,
+            options: Options {
+                poll_delay_ms: 100,
+                keep_alive_delay_ms: 1000,
+                keep_alive: true,
+            },
             token: String::new(),
             url: Url::from_str("wss://gateway-vaas.gdatasecurity.de").unwrap(),
         }

--- a/rust/src/cancellation.rs
+++ b/rust/src/cancellation.rs
@@ -1,0 +1,24 @@
+use std::time::Duration;
+
+/// The `CancellationToken` allows to cancel a request after a specific time
+/// if no response was received from the server.
+pub struct CancellationToken {
+    /// Duration after which the request is cancelled.
+    pub duration: Duration,
+}
+
+impl CancellationToken {
+    /// Create a new `CancellationToken` from seconds.
+    pub fn from_seconds(secs: u64) -> Self {
+        Self {
+            duration: Duration::from_secs(secs),
+        }
+    }
+
+    /// Create a new `CancellationToken` from minutes.
+    pub fn from_minutes(mins: u64) -> Self {
+        Self {
+            duration: Duration::from_secs(60 * mins),
+        }
+    }
+}

--- a/rust/src/connection.rs
+++ b/rust/src/connection.rs
@@ -155,8 +155,6 @@ impl Connection {
         self.wait_for_response(&guid, ct).await
     }
 
-    // TODO Refactor this function.
-    // Idea: Do not loop, but get a result from the channel.
     async fn wait_for_response(
         &self,
         guid: &str,

--- a/rust/src/connection.rs
+++ b/rust/src/connection.rs
@@ -168,6 +168,8 @@ impl Connection {
         self.wait_for_response(&guid, ct).await
     }
 
+    // TODO Refactor this function.
+    // Idea: Do not loop, but get a result from the channel.
     async fn wait_for_response(
         &self,
         guid: &str,

--- a/rust/src/connection.rs
+++ b/rust/src/connection.rs
@@ -127,7 +127,7 @@ impl Connection {
 
     async fn handle_unknown(
         file: &Path,
-        guid: &String,
+        guid: &str,
         response: VerdictResponse,
         upload_url: UploadUrl,
         result_channel: &mut ResultChannelRx,
@@ -143,7 +143,7 @@ impl Connection {
             return Err(Error::FailedUploadFile(response.status()));
         }
 
-        let resp = Self::wait_for_response(&guid, result_channel, ct).await?;
+        let resp = Self::wait_for_response(guid, result_channel, ct).await?;
         Ok(Verdict::try_from(&resp)?)
     }
 

--- a/rust/src/error.rs
+++ b/rust/src/error.rs
@@ -59,6 +59,9 @@ pub enum Error {
     /// Unauthorized
     #[error("Unauthorized")]
     Unauthorized,
+    /// All threads were dropped. This happens when the keep-alive and reader thread are dropped.
+    #[error("All threads were dropped.")]
+    ThreadsDropped,
 }
 
 impl From<PoisonError<std::sync::MutexGuard<'_, HashMap<std::string::String, message::State>>>>
@@ -71,6 +74,12 @@ impl From<PoisonError<std::sync::MutexGuard<'_, HashMap<std::string::String, mes
 
 impl From<PoisonError<std::sync::MutexGuard<'_, websockets::WebSocketWriteHalf>>> for Error {
     fn from(e: PoisonError<std::sync::MutexGuard<'_, websockets::WebSocketWriteHalf>>) -> Self {
+        Self::Lock(e.to_string())
+    }
+}
+
+impl From<tokio::sync::mpsc::error::SendError<Error>> for Error {
+    fn from(e: tokio::sync::mpsc::error::SendError<Error>) -> Self {
         Self::Lock(e.to_string())
     }
 }

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -78,6 +78,7 @@ pub mod error;
 pub mod message;
 mod sha256;
 mod vaas;
+mod options;
 
 pub use crate::vaas::Vaas;
 pub use builder::Builder;

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -16,15 +16,14 @@
 //!
 //! Check a file hash for malicious content:
 //! ```rust,no_run
-//! use vaas::{ Vaas, Sha256, CancellationTokenSource };
+//! use vaas::{ Vaas, Sha256, CancellationToken };
 //! use std::convert::TryFrom;
 //! use std::time::Duration;
 //!
 //! #[tokio::main]
 //! async fn main() -> vaas::error::VResult<()> {
 //!     // Cancel the request after 10 seconds if no response is received.
-//!     let cts = CancellationTokenSource::new();
-//!     cts.cancel_after(Duration::from_secs(10));
+//!     let ct = CancellationToken::from_seconds(10);
 //!
 //!     // Create the SHA256 we want to check.
 //!     let sha256 = Sha256::try_from("698CDA840A0B344639F0C5DBD5C629A847A27448A9A179CB6B7A648BC1186F23")?;
@@ -34,7 +33,7 @@
 //!         .build()?
 //!         .connect().await?;
 //!
-//!     let verdict = vaas.for_sha256(&sha256, &cts).await?;
+//!     let verdict = vaas.for_sha256(&sha256, &ct).await?;
 //!
 //!     // Prints "Clean", "Malicious" or "Unknown"
 //!     println!("{}", verdict);
@@ -73,6 +72,7 @@
 #![warn(rustdoc::missing_doc_code_examples)]
 
 mod builder;
+mod cancellation;
 mod connection;
 pub mod error;
 pub mod message;
@@ -82,6 +82,7 @@ mod vaas;
 
 pub use crate::vaas::Vaas;
 pub use builder::Builder;
+pub use cancellation::CancellationToken;
 pub use cancellation::*;
 pub use connection::Connection;
 pub use sha256::Sha256;

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -43,14 +43,14 @@
 //!
 //! Check a file for malicious content:
 //! ```rust,no_run
-//! use vaas::{ Vaas, Sha256, CancellationTokenSource };
+//! use vaas::{ Vaas, Sha256, CancellationToken };
 //! use std::convert::TryFrom;
 //! use std::time::Duration;
 //!
 //! #[tokio::main]
 //! async fn main() -> vaas::error::VResult<()> {
 //!     // Cancel the request after 10 seconds if no response is received.
-//!     let cts = CancellationToken::from_seconds(10);;
+//!     let ct = CancellationToken::from_seconds(10);;
 //!
 //!     // Create the SHA256 we want to check.
 //!     let file = std::path::PathBuf::from("myfile");
@@ -65,7 +65,7 @@
 //!     // Prints "Clean" or "Malicious"
 //!     println!("{}", verdict);
 //!     Ok(())
-//! }//!
+//! }
 #![warn(missing_docs)]
 #![warn(rustdoc::missing_doc_code_examples)]
 

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -50,8 +50,7 @@
 //! #[tokio::main]
 //! async fn main() -> vaas::error::VResult<()> {
 //!     // Cancel the request after 10 seconds if no response is received.
-//!     let cts = CancellationTokenSource::new();
-//!     cts.cancel_after(Duration::from_secs(10));
+//!     let cts = CancellationToken::from_seconds(10);;
 //!
 //!     // Create the SHA256 we want to check.
 //!     let file = std::path::PathBuf::from("myfile");
@@ -61,13 +60,12 @@
 //!         .build()?
 //!         .connect().await?;
 //!
-//!     let verdict = vaas.for_file(&file, &cts).await?;
+//!     let verdict = vaas.for_file(&file, &ct).await?;
 //!
 //!     // Prints "Clean" or "Malicious"
 //!     println!("{}", verdict);
 //!     Ok(())
-//! }
-//!
+//! }//!
 #![warn(missing_docs)]
 #![warn(rustdoc::missing_doc_code_examples)]
 

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -76,9 +76,9 @@ mod builder;
 mod connection;
 pub mod error;
 pub mod message;
+mod options;
 mod sha256;
 mod vaas;
-mod options;
 
 pub use crate::vaas::Vaas;
 pub use builder::Builder;

--- a/rust/src/message/auth_request.rs
+++ b/rust/src/message/auth_request.rs
@@ -1,6 +1,6 @@
-use crate::{error::VResult};
-use serde::{Deserialize, Serialize};
+use crate::error::VResult;
 use crate::message::kind::Kind;
+use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct AuthRequest {
@@ -10,7 +10,7 @@ pub struct AuthRequest {
 }
 
 impl AuthRequest {
-    pub fn new(token: String,session_id: Option<String>) -> Self {
+    pub fn new(token: String, session_id: Option<String>) -> Self {
         Self {
             kind: Kind::AuthRequest,
             token,

--- a/rust/src/message/auth_response.rs
+++ b/rust/src/message/auth_response.rs
@@ -1,7 +1,7 @@
 use crate::error::Error;
+use crate::message::kind::Kind;
 use serde::{Deserialize, Serialize};
 use std::convert::TryFrom;
-use crate::message::kind::Kind;
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct AuthResponse {

--- a/rust/src/message/error.rs
+++ b/rust/src/message/error.rs
@@ -1,7 +1,7 @@
 use crate::message::kind::Kind;
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
 
-#[derive(Serialize,Deserialize)]
+#[derive(Serialize, Deserialize)]
 pub struct ErrorResponse {
     #[serde(alias = "type")]
     pub error_type: String,

--- a/rust/src/message/error.rs
+++ b/rust/src/message/error.rs
@@ -1,10 +1,18 @@
+use crate::error::Error;
 use crate::message::kind::Kind;
 use serde::{Deserialize, Serialize};
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct ErrorResponse {
     #[serde(alias = "type")]
     pub error_type: String,
     pub text: String,
     pub kind: Kind,
+}
+
+impl TryFrom<&String> for ErrorResponse {
+    type Error = Error;
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        Ok(serde_json::from_str(value)?)
+    }
 }

--- a/rust/src/message/kind.rs
+++ b/rust/src/message/kind.rs
@@ -1,7 +1,7 @@
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
 
 #[derive(Copy, Clone, Debug, Serialize, Deserialize)]
-pub enum Kind{
+pub enum Kind {
     AuthRequest,
     AuthResponse,
     VerdictRequest,

--- a/rust/src/message/message_type.rs
+++ b/rust/src/message/message_type.rs
@@ -1,5 +1,5 @@
 use crate::error::Error;
-use crate::message::{VerdictResponse};
+use crate::message::VerdictResponse;
 use std::convert::TryFrom;
 
 pub enum MessageType {

--- a/rust/src/message/message_type.rs
+++ b/rust/src/message/message_type.rs
@@ -1,4 +1,5 @@
 use crate::error::Error;
+use crate::message::error::ErrorResponse;
 use crate::message::VerdictResponse;
 use std::convert::TryFrom;
 
@@ -6,7 +7,7 @@ pub enum MessageType {
     Ping,
     Pong,
     Close,
-    Response(VerdictResponse),
+    VerdictResponse(VerdictResponse),
 }
 
 impl TryFrom<&String> for MessageType {
@@ -14,7 +15,10 @@ impl TryFrom<&String> for MessageType {
 
     fn try_from(json: &String) -> Result<Self, Self::Error> {
         if let Ok(resp) = VerdictResponse::try_from(json) {
-            return Ok(MessageType::Response(resp));
+            return Ok(MessageType::VerdictResponse(resp));
+        }
+        if let Ok(err) = ErrorResponse::try_from(json) {
+            return Err(Error::ErrorResponse(err));
         }
         Err(Error::InvalidMessage(json.to_string()))
     }

--- a/rust/src/message/mod.rs
+++ b/rust/src/message/mod.rs
@@ -1,21 +1,21 @@
 //! Contains messages (requests and responses) between the client and the server endpoints.
 
+mod auth_request;
+mod auth_response;
+mod error;
+mod kind;
 mod message_type;
-mod verdict_request;
-mod verdict_response;
 mod state;
 mod upload_url;
 mod verdict;
-mod auth_request;
-mod kind;
-mod auth_response;
-mod error;
+mod verdict_request;
+mod verdict_response;
 
-pub(super) use message_type::MessageType;
-pub(super) use verdict_request::VerdictRequest;
-pub(super) use verdict_response::VerdictResponse;
-pub(super) use state::State;
-pub(super) use upload_url::UploadUrl;
 pub(super) use auth_request::AuthRequest;
 pub(super) use auth_response::AuthResponse;
+pub(super) use message_type::MessageType;
+pub(super) use state::State;
+pub(super) use upload_url::UploadUrl;
 pub use verdict::Verdict;
+pub(super) use verdict_request::VerdictRequest;
+pub(super) use verdict_response::VerdictResponse;

--- a/rust/src/message/mod.rs
+++ b/rust/src/message/mod.rs
@@ -5,7 +5,6 @@ mod auth_response;
 mod error;
 mod kind;
 mod message_type;
-mod state;
 mod upload_url;
 mod verdict;
 mod verdict_request;
@@ -13,8 +12,8 @@ mod verdict_response;
 
 pub(super) use auth_request::AuthRequest;
 pub(super) use auth_response::AuthResponse;
+pub(super) use error::ErrorResponse;
 pub(super) use message_type::MessageType;
-pub(super) use state::State;
 pub(super) use upload_url::UploadUrl;
 pub use verdict::Verdict;
 pub(super) use verdict_request::VerdictRequest;

--- a/rust/src/message/state.rs
+++ b/rust/src/message/state.rs
@@ -1,6 +1,0 @@
-use crate::message::{VerdictRequest, VerdictResponse};
-
-pub enum State {
-    Send(VerdictRequest),
-    Received(VerdictResponse),
-}

--- a/rust/src/message/upload_url.rs
+++ b/rust/src/message/upload_url.rs
@@ -1,7 +1,7 @@
+use serde::{Deserialize, Serialize};
 use std::fmt;
 use std::fmt::Formatter;
 use std::ops::Deref;
-use serde::{Serialize, Deserialize};
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 pub struct UploadUrl(pub String);

--- a/rust/src/message/verdict.rs
+++ b/rust/src/message/verdict.rs
@@ -14,7 +14,7 @@ pub enum Verdict {
     Clean,
     /// Malicious content found.
     Malicious,
-    /// Unknown if clean or malicous.
+    /// Unknown if clean or malicious.
     Unknown {
         /// Pre-signed URL to submit a file for further analysis to get a `Clean` or `Malicious` verdict.
         upload_url: UploadUrl,

--- a/rust/src/message/verdict.rs
+++ b/rust/src/message/verdict.rs
@@ -2,13 +2,13 @@ use crate::error::Error;
 use crate::error::Error::NoUploadUrl;
 use crate::message::upload_url::UploadUrl;
 use crate::message::VerdictResponse;
+use serde::{Deserialize, Serialize};
 use std::convert::TryFrom;
 use std::fmt;
-use serde::{Serialize, Deserialize};
 
 /// A `Verdict` is a response from the server that indicates whether the
 /// submission is `Clean`, `Malicious`, or `Unknown`.
-#[derive(Debug, PartialEq, Clone,  Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
 pub enum Verdict {
     /// No malicious content found.
     Clean,

--- a/rust/src/message/verdict_request.rs
+++ b/rust/src/message/verdict_request.rs
@@ -1,6 +1,6 @@
+use crate::message::kind::Kind;
 use crate::{error::VResult, sha256::Sha256};
 use serde::{Deserialize, Serialize};
-use crate::message::kind::Kind;
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct VerdictRequest {
@@ -24,9 +24,13 @@ impl VerdictRequest {
         Ok(serde_json::to_string(self)?)
     }
 
-    pub fn kind(&self) -> Kind { self.kind }
+    pub fn kind(&self) -> Kind {
+        self.kind
+    }
 
-    pub fn guid(&self) -> &str { &self.guid }
+    pub fn guid(&self) -> &str {
+        &self.guid
+    }
 
     pub fn sha256(&self) -> &str {
         &self.sha256

--- a/rust/src/message/verdict_request.rs
+++ b/rust/src/message/verdict_request.rs
@@ -23,16 +23,7 @@ impl VerdictRequest {
     pub fn to_json(&self) -> VResult<String> {
         Ok(serde_json::to_string(self)?)
     }
-
-    pub fn kind(&self) -> Kind {
-        self.kind
-    }
-
     pub fn guid(&self) -> &str {
         &self.guid
-    }
-
-    pub fn sha256(&self) -> &str {
-        &self.sha256
     }
 }

--- a/rust/src/options.rs
+++ b/rust/src/options.rs
@@ -1,6 +1,5 @@
 #[derive(Debug, Clone)]
 pub(crate) struct Options {
-    pub poll_delay_ms: u64,
     pub keep_alive_delay_ms: u64,
     pub keep_alive: bool,
 }

--- a/rust/src/options.rs
+++ b/rust/src/options.rs
@@ -1,0 +1,6 @@
+#[derive(Debug, Clone)]
+pub(crate) struct Options {
+    pub poll_delay_ms: u64,
+    pub keep_alive_delay_ms: u64,
+    pub keep_alive: bool,
+}

--- a/rust/src/vaas.rs
+++ b/rust/src/vaas.rs
@@ -4,6 +4,7 @@ use crate::builder::Builder;
 use crate::connection::Connection;
 use crate::error::{Error, VResult};
 use crate::message::{AuthRequest, AuthResponse};
+use crate::options::Options;
 use reqwest::Url;
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -19,8 +20,8 @@ pub(super) enum ThreadSyncMsg {
 #[derive(Debug, Clone)]
 pub struct Vaas {
     pub(super) token: String,
-    pub(super) poll_delay_ms: u64,
     pub(super) url: Url,
+    pub(super) options: Options,
 }
 
 impl Vaas {
@@ -43,8 +44,12 @@ impl Vaas {
             session_id,
             message_states,
             ch_sender,
-            poll_delay_ms: self.poll_delay_ms,
+            options: self.options,
         };
+
+        if connection.options.keep_alive {
+            connection.start_keep_alive().await;
+        }
 
         Connection::start_reader_loop(ws_reader, ch_receiver, reader_messages).await;
         Ok(connection)

--- a/rust/src/vaas.rs
+++ b/rust/src/vaas.rs
@@ -44,11 +44,9 @@ impl Vaas {
         ws_writer: &mut WebSocketWriteHalf,
     ) -> VResult<String> {
         let auth_request = AuthRequest::new(self.token.clone(), None).to_json()?;
-
         ws_writer.send_text(auth_request).await?;
 
         let frame = ws_reader.receive().await?;
-
         let response = match frame {
             Frame::Text { payload: json, .. } => AuthResponse::try_from(&json)?,
             _ => return Err(Error::InvalidFrame),

--- a/rust/src/vaas.rs
+++ b/rust/src/vaas.rs
@@ -51,7 +51,10 @@ impl Vaas {
             connection.start_keep_alive().await;
         }
 
-        Connection::start_reader_loop(ws_reader, ch_receiver, reader_messages).await;
+        // TODO: Save the handle somewhere in the connection and on a connection drop, abort the handle
+        // Do the same for the start_keep_alive() function
+        // Then remove the ch_sender
+        let handle = Connection::start_reader_loop(ws_reader, ch_receiver, reader_messages).await;
         Ok(connection)
     }
 

--- a/rust/tests/real_api_integration_tests.rs
+++ b/rust/tests/real_api_integration_tests.rs
@@ -210,7 +210,6 @@ async fn from_files_unknown_files() {
 
     let vaas = get_vaas().await;
     let ct = CancellationToken::from_minutes(5);
-
     let verdicts = vaas.for_file_list(&files, &ct).await;
 
     std::fs::remove_file(tmp_file1).unwrap();

--- a/rust/tests/real_api_integration_tests.rs
+++ b/rust/tests/real_api_integration_tests.rs
@@ -179,7 +179,7 @@ async fn from_file_single_clean_file() {
 }
 
 #[tokio::test]
-// #[ignore = "Skip this test for now, as the test takes multiple minutes."]
+#[ignore = "Skip this test for now, as the test takes multiple minutes."]
 async fn from_file_single_unknown_file() {
     let unknown: String = rand::thread_rng()
         .sample_iter(&Alphanumeric)
@@ -200,7 +200,7 @@ async fn from_file_single_unknown_file() {
 }
 
 #[tokio::test]
-// #[ignore = "Skip this test for now, as it the takes multiple minutes."]
+#[ignore = "Skip this test for now, as it the takes multiple minutes."]
 async fn from_files_unknown_files() {
     let unknown1: String = rand::thread_rng()
         .sample_iter(&Alphanumeric)

--- a/rust/tests/real_api_integration_tests.rs
+++ b/rust/tests/real_api_integration_tests.rs
@@ -1,14 +1,13 @@
 use futures::future::try_join_all;
 use rand::{distributions::Alphanumeric, Rng};
-use std::{convert::TryFrom, time::Duration};
-use vaas::{message::Verdict, CancellationTokenSource, Connection, Sha256, Vaas};
+use std::convert::TryFrom;
+use vaas::{message::Verdict, CancellationToken, Connection, Sha256, Vaas};
 
 async fn get_vaas() -> Connection {
     let token = dotenv::var("VAAS_TOKEN")
         .expect("No TOKEN environment variable set to be used in the integration tests!");
 
     Vaas::builder(token)
-        .poll_delay_ms(100)
         .build()
         .unwrap()
         .connect()
@@ -19,10 +18,8 @@ async fn get_vaas() -> Connection {
 #[tokio::test]
 async fn from_sha256_list_multiple_hashes() {
     let vaas = get_vaas().await;
-    let cts = CancellationTokenSource::new();
-    cts.cancel_after(Duration::from_secs(10));
+    let ct = CancellationToken::from_seconds(10);
     let expected_url = "https://upload-vaas.gdatasecurity.de/upload";
-    cts.cancel_after(Duration::from_secs(10));
     let sha256_malicious =
         Sha256::try_from("000005c43196142f01d615a67b7da8a53cb0172f8e9317a2ec9a0a39a1da6fe8")
             .unwrap();
@@ -38,7 +35,7 @@ async fn from_sha256_list_multiple_hashes() {
         sha256_unknown.clone(),
     ];
 
-    let results = vaas.for_sha256_list(&sha256_list, &cts).await;
+    let results = vaas.for_sha256_list(&sha256_list, &ct).await;
 
     assert_eq!(&Verdict::Malicious, results[0].as_ref().unwrap());
     assert_eq!(&Verdict::Clean, results[1].as_ref().unwrap());
@@ -53,13 +50,12 @@ async fn from_sha256_list_multiple_hashes() {
 #[tokio::test]
 async fn from_sha256_single_malicious_hash() {
     let vaas = get_vaas().await;
-    let cts = CancellationTokenSource::new();
-    cts.cancel_after(Duration::from_secs(10));
+    let ct = CancellationToken::from_seconds(10);
     let sha256 =
         Sha256::try_from("000005c43196142f01d615a67b7da8a53cb0172f8e9317a2ec9a0a39a1da6fe8")
             .unwrap();
 
-    let verdict = vaas.for_sha256(&sha256, &cts).await;
+    let verdict = vaas.for_sha256(&sha256, &ct).await;
 
     assert_eq!(Verdict::Malicious, verdict.unwrap());
 }
@@ -67,8 +63,7 @@ async fn from_sha256_single_malicious_hash() {
 #[tokio::test]
 async fn from_sha256_multiple_malicious_hash() {
     let vaas = get_vaas().await;
-    let cts = CancellationTokenSource::new();
-    cts.cancel_after(Duration::from_secs(10));
+    let ct = CancellationToken::from_seconds(10);
     let sha256_1 =
         Sha256::try_from("000005c43196142f01d615a67b7da8a53cb0172f8e9317a2ec9a0a39a1da6fe8")
             .unwrap();
@@ -78,9 +73,9 @@ async fn from_sha256_multiple_malicious_hash() {
     let sha256_3 =
         Sha256::try_from("00000f83e3120f79a21b7b395dd3dd6a9c31ce00857f78d7cf487476ca75fd1a")
             .unwrap();
-    let verdict_1 = vaas.for_sha256(&sha256_1, &cts).await;
-    let verdict_2 = vaas.for_sha256(&sha256_2, &cts).await;
-    let verdict_3 = vaas.for_sha256(&sha256_3, &cts).await;
+    let verdict_1 = vaas.for_sha256(&sha256_1, &ct).await;
+    let verdict_2 = vaas.for_sha256(&sha256_2, &ct).await;
+    let verdict_3 = vaas.for_sha256(&sha256_3, &ct).await;
 
     assert_eq!(Verdict::Malicious, verdict_1.unwrap());
     assert_eq!(Verdict::Malicious, verdict_2.unwrap());
@@ -90,8 +85,7 @@ async fn from_sha256_multiple_malicious_hash() {
 #[tokio::test]
 async fn from_sha256_multiple_clean_hash() {
     let vaas = get_vaas().await;
-    let cts = CancellationTokenSource::new();
-    cts.cancel_after(Duration::from_secs(10));
+    let ct = CancellationToken::from_seconds(10);
     let sha256_1 =
         Sha256::try_from("698CDA840A0B3D4639F0C5DBD5C629A847A27448A9A179CB6B7A648BC1186F23")
             .unwrap();
@@ -101,9 +95,9 @@ async fn from_sha256_multiple_clean_hash() {
     let sha256_3 =
         Sha256::try_from("4447FAACEFABA8F040822101E2A4103031660DE9139E70ECFF9AA3A89455A783")
             .unwrap();
-    let verdict_1 = vaas.for_sha256(&sha256_1, &cts).await;
-    let verdict_2 = vaas.for_sha256(&sha256_2, &cts).await;
-    let verdict_3 = vaas.for_sha256(&sha256_3, &cts).await;
+    let verdict_1 = vaas.for_sha256(&sha256_1, &ct).await;
+    let verdict_2 = vaas.for_sha256(&sha256_2, &ct).await;
+    let verdict_3 = vaas.for_sha256(&sha256_3, &ct).await;
 
     assert_eq!(Verdict::Clean, verdict_1.unwrap());
     assert_eq!(Verdict::Clean, verdict_2.unwrap());
@@ -113,8 +107,7 @@ async fn from_sha256_multiple_clean_hash() {
 #[tokio::test]
 async fn from_sha256_multiple_unknown_hash() {
     let vaas = get_vaas().await;
-    let cts = CancellationTokenSource::new();
-    cts.cancel_after(Duration::from_secs(10));
+    let t = CancellationToken::from_seconds(10);
     let expected_url = "https://upload-vaas.gdatasecurity.de/upload";
     let sha256_1 =
         Sha256::try_from("110005c43196142f01d615a67b7da8a53cb0172f8e9317a2ec9a0a39a1da6fe8")
@@ -125,9 +118,9 @@ async fn from_sha256_multiple_unknown_hash() {
     let sha256_3 =
         Sha256::try_from("11000f83e3120f79a21b7b395dd3dd6a9c31ce00857f78d7cf487476ca75fd1a")
             .unwrap();
-    let verdict_1 = vaas.for_sha256(&sha256_1, &cts).await.unwrap();
-    let verdict_2 = vaas.for_sha256(&sha256_2, &cts).await.unwrap();
-    let verdict_3 = vaas.for_sha256(&sha256_3, &cts).await.unwrap();
+    let verdict_1 = vaas.for_sha256(&sha256_1, &t).await.unwrap();
+    let verdict_2 = vaas.for_sha256(&sha256_2, &t).await.unwrap();
+    let verdict_3 = vaas.for_sha256(&sha256_3, &t).await.unwrap();
 
     if let Verdict::Unknown { upload_url } = verdict_1 {
         assert!(upload_url.starts_with(expected_url));
@@ -153,10 +146,9 @@ async fn from_file_single_malicious_file() {
     std::fs::write(&tmp_file, eicar.as_bytes()).unwrap();
 
     let vaas = get_vaas().await;
-    let cts = CancellationTokenSource::new();
-    cts.cancel_after(Duration::from_secs(10));
+    let ct = CancellationToken::from_seconds(10);
 
-    let verdict = vaas.for_file(&tmp_file, &cts).await;
+    let verdict = vaas.for_file(&tmp_file, &ct).await;
 
     std::fs::remove_file(&tmp_file).unwrap();
     assert_eq!(Verdict::Malicious, verdict.unwrap());
@@ -169,10 +161,9 @@ async fn from_file_single_clean_file() {
     std::fs::write(&tmp_file, clean).unwrap();
 
     let vaas = get_vaas().await;
-    let cts = CancellationTokenSource::new();
-    cts.cancel_after(Duration::from_secs(10));
+    let ct = CancellationToken::from_seconds(10);
 
-    let verdict = vaas.for_file(&tmp_file, &cts).await;
+    let verdict = vaas.for_file(&tmp_file, &ct).await;
 
     std::fs::remove_file(&tmp_file).unwrap();
     assert_eq!(Verdict::Clean, verdict.unwrap());
@@ -190,10 +181,9 @@ async fn from_file_single_unknown_file() {
     std::fs::write(&tmp_file, unknown.as_bytes()).unwrap();
 
     let vaas = get_vaas().await;
-    let cts = CancellationTokenSource::new();
-    cts.cancel_after(Duration::from_secs(5 * 60));
+    let ct = CancellationToken::from_minutes(5);
 
-    let verdict = vaas.for_file(&tmp_file, &cts).await;
+    let verdict = vaas.for_file(&tmp_file, &ct).await;
 
     std::fs::remove_file(&tmp_file).unwrap();
     assert_eq!(Verdict::Clean, verdict.unwrap());
@@ -219,10 +209,9 @@ async fn from_files_unknown_files() {
     let files = vec![tmp_file1.clone(), tmp_file2.clone()];
 
     let vaas = get_vaas().await;
-    let cts = CancellationTokenSource::new();
-    cts.cancel_after(Duration::from_secs(5 * 60));
+    let ct = CancellationToken::from_minutes(5);
 
-    let verdicts = vaas.for_file_list(&files, &cts).await;
+    let verdicts = vaas.for_file_list(&files, &ct).await;
 
     std::fs::remove_file(tmp_file1).unwrap();
     std::fs::remove_file(tmp_file2).unwrap();
@@ -233,8 +222,7 @@ async fn from_files_unknown_files() {
 #[tokio::test]
 async fn from_sha256_multiple_clean_hash_on_separate_thread() {
     let vaas = get_vaas().await;
-    let cts = CancellationTokenSource::new();
-    cts.cancel_after(Duration::from_secs(10));
+    let ct = CancellationToken::from_seconds(10);
     let sha256_1 =
         Sha256::try_from("698CDA840A0B3D4639F0C5DBD5C629A847A27448A9A179CB6B7A648BC1186F23")
             .unwrap();
@@ -246,9 +234,9 @@ async fn from_sha256_multiple_clean_hash_on_separate_thread() {
             .unwrap();
 
     let (v1, v2, v3) = tokio::spawn(async move {
-        let v1 = vaas.for_sha256(&sha256_1, &cts).await;
-        let v2 = vaas.for_sha256(&sha256_2, &cts).await;
-        let v3 = vaas.for_sha256(&sha256_3, &cts).await;
+        let v1 = vaas.for_sha256(&sha256_1, &ct).await;
+        let v2 = vaas.for_sha256(&sha256_2, &ct).await;
+        let v3 = vaas.for_sha256(&sha256_3, &ct).await;
         (v1, v2, v3)
     })
     .await
@@ -262,8 +250,7 @@ async fn from_sha256_multiple_clean_hash_on_separate_thread() {
 #[tokio::test]
 async fn from_sha256_multiple_clean_hash_await_concurrent_fixed_jobs() {
     let vaas = get_vaas().await;
-    let cts = CancellationTokenSource::new();
-    cts.cancel_after(Duration::from_secs(10));
+    let ct = CancellationToken::from_seconds(10);
     let sha256_1 =
         Sha256::try_from("698CDA840A0B3D4639F0C5DBD5C629A847A27448A9A179CB6B7A648BC1186F23")
             .unwrap();
@@ -274,9 +261,9 @@ async fn from_sha256_multiple_clean_hash_await_concurrent_fixed_jobs() {
         Sha256::try_from("4447FAACEFABA8F040822101E2A4103031660DE9139E70ECFF9AA3A89455A783")
             .unwrap();
 
-    let v1 = vaas.for_sha256(&sha256_1, &cts);
-    let v2 = vaas.for_sha256(&sha256_2, &cts);
-    let v3 = vaas.for_sha256(&sha256_3, &cts);
+    let v1 = vaas.for_sha256(&sha256_1, &ct);
+    let v2 = vaas.for_sha256(&sha256_2, &ct);
+    let v3 = vaas.for_sha256(&sha256_3, &ct);
 
     let (v1, v2, v3) = tokio::join!(v1, v2, v3);
     assert_eq!(Verdict::Clean, v1.unwrap());
@@ -287,8 +274,7 @@ async fn from_sha256_multiple_clean_hash_await_concurrent_fixed_jobs() {
 #[tokio::test]
 async fn from_sha256_multiple_clean_hash_await_concurrent_unknown_jobs() {
     let vaas = get_vaas().await;
-    let cts = CancellationTokenSource::new();
-    cts.cancel_after(Duration::from_secs(10));
+    let ct = CancellationToken::from_seconds(10);
     let sha256_1 =
         Sha256::try_from("698CDA840A0B3D4639F0C5DBD5C629A847A27448A9A179CB6B7A648BC1186F23")
             .unwrap();
@@ -300,9 +286,9 @@ async fn from_sha256_multiple_clean_hash_await_concurrent_unknown_jobs() {
             .unwrap();
 
     let handles = vec![
-        vaas.for_sha256(&sha256_1, &cts),
-        vaas.for_sha256(&sha256_2, &cts),
-        vaas.for_sha256(&sha256_3, &cts),
+        vaas.for_sha256(&sha256_1, &ct),
+        vaas.for_sha256(&sha256_2, &ct),
+        vaas.for_sha256(&sha256_3, &ct),
     ];
 
     let result = try_join_all(handles).await;

--- a/rust/tests/real_api_integration_tests.rs
+++ b/rust/tests/real_api_integration_tests.rs
@@ -179,7 +179,7 @@ async fn from_file_single_clean_file() {
 }
 
 #[tokio::test]
-#[ignore = "Skip this test for now, as the test takes multiple minutes."]
+//#[ignore = "Skip this test for now, as the test takes multiple minutes."]
 async fn from_file_single_unknown_file() {
     let unknown: String = rand::thread_rng()
         .sample_iter(&Alphanumeric)
@@ -200,7 +200,7 @@ async fn from_file_single_unknown_file() {
 }
 
 #[tokio::test]
-#[ignore = "Skip this test for now, as it the takes multiple minutes."]
+//#[ignore = "Skip this test for now, as it the takes multiple minutes."]
 async fn from_files_unknown_files() {
     let unknown1: String = rand::thread_rng()
         .sample_iter(&Alphanumeric)


### PR DESCRIPTION
This PR refactors the Rust SDK quite a bit.

Key points are:

- No more "pull loops". Instead messaging between threads is used
- Removed the state machine as with the new protocol, there aren't as many message states as before
- Improved error handling for server errors and errors in threads
