### PR TITLE
make the Error enum non-exhaustive

### DIFF
--- a/rust/src/error.rs
+++ b/rust/src/error.rs
@@ -12,6 +12,7 @@ use websockets::WebSocketError;
 pub type VResult<T> = Result<T, Error>;
 
 /// `Error` is the only error type in the `vaas` API.
+#[non_exhaustive]
 #[derive(Error, Debug, Clone)]
 pub enum Error {
     /// A websocket error occurred.


### PR DESCRIPTION
Make the `Error` type of the Rust SDK non-exhaustive. This prevents the public API from breaking, when we add a new error type. Else all downstream code would need to handle the new error type explicitly, instead of implicitly with a "catch all".