### PR TITLE
Repair examples

### DIFF
--- a/rust/examples/gscan/Cargo.toml
+++ b/rust/examples/gscan/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 
 [dependencies]
 vaas = { path = "../.." }
-tokio = "1.9"
+tokio = { version = "1.9", features = [ "rt-multi-thread", "macros"] }
 clap = "2.33"
 futures = "0.3"
 dotenv = "0.15"

--- a/rust/examples/gscan/src/main.rs
+++ b/rust/examples/gscan/src/main.rs
@@ -1,6 +1,6 @@
 use clap::{App, Arg};
 use std::{path::PathBuf, str::FromStr};
-use vaas::{error::VResult, message::Verdict, CancellationTokenSource, Vaas};
+use vaas::{error::VResult, message::Verdict, CancellationToken, Vaas};
 
 #[tokio::main]
 async fn main() -> VResult<()> {
@@ -70,9 +70,7 @@ async fn scan_files<'a>(
         .connect()
         .await?;
 
-    let ct = CancellationTokenSource::new();
-    ct.cancel_after(std::time::Duration::from_secs(10 * 60));
-
+    let ct = CancellationToken::from_minutes(1);
     let verdicts = vaas.for_file_list(files, &ct).await;
     let results = files.iter().zip(verdicts).collect();
 

--- a/rust/examples/kde_dolphin/Cargo.toml
+++ b/rust/examples/kde_dolphin/Cargo.toml
@@ -11,7 +11,7 @@ publish = false
 [dependencies]
 slint = "0.2"
 vaas = { path = "../.."}
-tokio = "1"
+tokio = { version = "1.9", features = ["rt", "macros", "rt-multi-thread"] }
 structopt = "0.3"
 
 [build-dependencies]

--- a/rust/examples/kde_dolphin/src/main.rs
+++ b/rust/examples/kde_dolphin/src/main.rs
@@ -1,7 +1,7 @@
 use slint::Model;
-use std::{env, path::PathBuf, rc::Rc, time::Duration};
+use std::{env, path::PathBuf, rc::Rc};
 use structopt::StructOpt;
-use vaas::{CancellationTokenSource, Vaas};
+use vaas::{CancellationToken, Vaas};
 slint::include_modules!();
 
 #[tokio::main]
@@ -27,8 +27,7 @@ async fn main() {
                     .await
                     .expect("Failed to connect to VaaS.");
 
-                let cts = CancellationTokenSource::new();
-                cts.cancel_after(Duration::from_secs(60 * 5));
+                let cts = CancellationToken::from_minutes(1);
 
                 let files = file_items_clone
                     .iter()


### PR DESCRIPTION
Fix all compilation errors in the Rust examples.

We should port the examples to the new OpenID API in the near future and add the examples to the CI workflow, such that we see, if they are breaking.