### PR TITLE
Take references and Url in get_token

### DIFF
--- a/rust/src/vaas.rs
+++ b/rust/src/vaas.rs
@@ -19,14 +19,14 @@ pub struct Vaas {
 impl Vaas {
     /// Get an OpenID Connect token to use for authentication.
     pub async fn get_token(
-        client_id: String,
-        client_secret: String,
-        token_endpoint: String,
+        client_id: &str,
+        client_secret: &str,
+        token_endpoint: Url,
     ) -> VResult<String> {
         let params = [
             ("client_id", client_id),
             ("client_secret", client_secret),
-            ("grant_type", "client_credentials".to_string()),
+            ("grant_type", "client_credentials"),
         ];
         let client = reqwest::Client::new();
         let token_response = client.post(token_endpoint).form(&params).send().await?;

--- a/rust/tests/real_api_integration_tests.rs
+++ b/rust/tests/real_api_integration_tests.rs
@@ -5,17 +5,19 @@ use std::convert::TryFrom;
 use vaas::{message::Verdict, CancellationToken, Connection, Sha256, Vaas};
 
 async fn get_vaas() -> Connection {
-    let token_url = dotenv::var("TOKEN_URL")
-        .expect("No TOKEN_URL environment variable set to be used in the integration tests!");
+    let token_url: Url = dotenv::var("TOKEN_URL")
+        .expect("No TOKEN_URL environment variable set to be used in the integration tests")
+        .parse()
+        .expect("Failed to parse TOKEN_URL environment variable");
     let client_id = dotenv::var("CLIENT_ID")
-        .expect("No CLIENT_ID environment variable set to be used in the integration tests!");
+        .expect("No CLIENT_ID environment variable set to be used in the integration tests");
     let client_secret = dotenv::var("CLIENT_SECRET")
-        .expect("No CLIENT_SECRET environment variable set to be used in the integration tests!");
-    let token = Vaas::get_token(client_id, client_secret, token_url)
+        .expect("No CLIENT_SECRET environment variable set to be used in the integration tests");
+    let token = Vaas::get_token(&client_id, &client_secret, token_url)
         .await
         .unwrap();
     let vaas_url = dotenv::var("VAAS_URL")
-        .expect("No VAAS_URL environment variable set to be used in the integration tests!");
+        .expect("No VAAS_URL environment variable set to be used in the integration tests");
     Vaas::builder(token)
         .url(Url::parse(&vaas_url).unwrap())
         .build()


### PR DESCRIPTION
Take references instead of values as ownership is not required. Take an `Url` instead of an `String` to enforce type safety.