### PR TITLE
Java: Workaround for JDK HttpClient omitting content-length if 0

### DIFF
--- a/java/src/main/java/de/gdata/vaas/Vaas.java
+++ b/java/src/main/java/de/gdata/vaas/Vaas.java
@@ -13,6 +13,7 @@ import java.net.URL;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.net.http.HttpClient.Version;
 import java.net.http.HttpRequest.BodyPublishers;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -546,10 +547,8 @@ public class Vaas {
         var builder = HttpRequest
                 .newBuilder(new URI(url))
                 .header("Authorization", authToken)
+                .version(Version.HTTP_1_1)
                 .PUT(HttpRequest.BodyPublishers.ofFile(file));
-        if (Files.size(file) == 0) {
-            builder.header("Content-Length", "0");
-        }
         var request = builder.build();
 
         var futureResponse = this.httpClient


### PR DESCRIPTION
The JDK HttpClient has the questionable behavior of omitting the content-length if 0. This would be fine for the noBody publisher, but it does that for any body publisher (file, stream, ...).

Workaround: HTTP/2 allows the client to omit the content-length, HTTP 1.1 does not.