### PR TITLE
java: Disable uploading build scans by default, update example dependencies

### DIFF
--- a/java/.run/Test.run.xml
+++ b/java/.run/Test.run.xml
@@ -4,7 +4,7 @@
       <option name="executionName" />
       <option name="externalProjectPath" value="$PROJECT_DIR$" />
       <option name="externalSystemIdString" value="GRADLE" />
-      <option name="scriptParameters" value="test --scan" />
+      <option name="scriptParameters" value="test" />
       <option name="taskDescriptions">
         <list />
       </option>

--- a/java/examples/VaasExample/build.gradle
+++ b/java/examples/VaasExample/build.gradle
@@ -11,7 +11,7 @@ repositories {
 
 dependencies {
     implementation 'org.slf4j:slf4j-nop:2.0.13'
-    implementation 'de.gdata:vaas:6.4.2'
+    implementation 'de.gdata:vaas:8.0.0'
 }
 
 task fileScan(type: JavaExec) {


### PR DESCRIPTION
Sometimes, gradle builds don't terminate. Investigation revealed that this is caused by gradle trying to upload a build scan (https://docs.gradle.org/current/userguide/build_scans.html) to gradle's servers. This may cause a ToS warning, which isn't answered by the IDE - hence gradle hangs.

The reason build scans are even uploaded in the first place is because we're setting the `--scan` flag by default. I propose we remove that and only upload build scans when explicitly configured to.

Also, the example was running on an outdated version of the SDK, update that as well (renovate is sleeping on this?)