### PR TITLE
pin go to minor version

### DIFF
--- a/.github/workflows/ci-golang.yaml
+++ b/.github/workflows/ci-golang.yaml
@@ -121,7 +121,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.22.2
+          go-version-file: golang/vaas/go.mod
           check-latest: true
           cache: true
           cache-dependency-path: golang/vaas/go.sum

--- a/golang/vaas/go.mod
+++ b/golang/vaas/go.mod
@@ -1,6 +1,6 @@
 module github.com/GDATASoftwareAG/vaas/golang/vaas
 
-go 1.22
+go 1.21
 
 require (
 	github.com/Noooste/websocket v1.0.3

--- a/golang/vaas/go.mod
+++ b/golang/vaas/go.mod
@@ -1,6 +1,6 @@
 module github.com/GDATASoftwareAG/vaas/golang/vaas
 
-go 1.22.3
+go 1.22
 
 require (
 	github.com/Noooste/websocket v1.0.3


### PR DESCRIPTION
the version in the go.mod file also pins the minimum version one has to have to use to use this library. Go 21 would also still be valid.