### PR TITLE
Fix silent drop of non-seekable ReadClosers

### DIFF
--- a/golang/vaas/pkg/vaas/vaas.go
+++ b/golang/vaas/pkg/vaas/vaas.go
@@ -52,6 +52,10 @@ const (
 	pingPeriod = (pongWait * 9) / 10
 )
 
+var (
+	ErrUnsupportedReader = errors.New("unsupported reader")
+)
+
 // vaas provides the implementation of the Vaas interface.
 type vaas struct {
 	logger              *log.Logger
@@ -542,22 +546,17 @@ func (v *vaas) uploadFile(file io.Reader, contentLength int64, url string, token
 		// Here can add support for various io.Reader, which are not supported by the http package.
 		if req.ContentLength == 0 {
 			switch t := file.(type) {
-			case *os.File:
-				var info os.FileInfo
-				if info, err = t.Stat(); err != nil {
-					return err
-				}
-				req.ContentLength = info.Size()
-			case io.ReadCloser:
-				if s, ok := file.(io.Seeker); ok {
-					if size, err := s.Seek(0, io.SeekEnd); err == nil {
-						if _, err = s.Seek(0, io.SeekStart); err == nil {
-							req.ContentLength = size
-						}
+			case io.Seeker:
+				var size int64
+				if size, err = t.Seek(0, io.SeekEnd); err == nil {
+					if _, err = t.Seek(0, io.SeekStart); err == nil {
+						req.ContentLength = size
+						break
 					}
 				}
+				return err
 			default:
-				return fmt.Errorf("unsupported reader (%T), can not determine content length", file)
+				return ErrUnsupportedReader
 			}
 		}
 	}

--- a/golang/vaas/pkg/vaas/vaas.go
+++ b/golang/vaas/pkg/vaas/vaas.go
@@ -367,12 +367,14 @@ func (v *vaas) ForUrl(ctx context.Context, url string) (msg.VaasVerdict, error) 
 
 // ForStream sends an analysis request for a file stream to the Vaas server and returns the verdict.
 // The analysis can be canceled using the provided context.
+// ContentLength should either be non-zero or the stream must be seekable.
 //
 // Example usage:
 //
 //	vaasClient := vaas.New(options, "wss://example.authentication.endpoint")
 //	ctx := context.Background()
-//	verdict, err := vaasClient.ForStream(ctx, stream)
+//	contentLength := 1234
+//	verdict, err := vaasClient.ForStream(ctx, stream, contentLength)
 //	if err != nil {
 //	    log.Fatalf("Failed to get verdict: %v", err)
 //	}

--- a/golang/vaas/pkg/vaas/vaas_test.go
+++ b/golang/vaas/pkg/vaas/vaas_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -319,6 +320,24 @@ func TestVaas_ForStream_WithStreamFromUrl(t *testing.T) {
 
 	if verdict.Verdict != msg.Malicious {
 		t.Errorf("verdict should be %v, got %v", msg.Malicious, verdict.Verdict)
+	}
+}
+
+func TestVaas_ForStream_WithStreamFromUrlZeroContentLength(t *testing.T) {
+	response, _ := http.Get("https://secure.eicar.org/eicar.com.txt")
+
+	fixture := new(testFixture)
+	VaasClient := fixture.setUp(t)
+	defer fixture.tearDown(t)
+
+	_, err := VaasClient.ForStream(context.Background(), response.Body, 0)
+
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+
+	if !errors.Is(err, ErrUnsupportedReader) {
+		t.Fatalf("expected error %v, got %v", ErrUnsupportedReader, err)
 	}
 }
 


### PR DESCRIPTION
Hi, I've noticed that you silently drop non-seekable `io.ReadCloser`. Of course this can only happen in `ForStream` with zero content length, so maybe we should also add an early return for that case?