### PR TITLE
Golang: Make VaaS client closeable

### DIFF
--- a/.github/workflows/ci-golang.yaml
+++ b/.github/workflows/ci-golang.yaml
@@ -37,6 +37,8 @@ env:
 jobs:
   build-golang:
     runs-on: ubuntu-latest
+    container:
+      image: golang:latest
     steps:
       - uses: actions/checkout@v4
 
@@ -68,13 +70,6 @@ jobs:
           echo "VAAS_USER_NAME=${{ secrets.DEVELOP_VAAS_USER_NAME }}" >> $GITHUB_ENV
           echo "VAAS_PASSWORD=${{ secrets.DEVELOP_VAAS_PASSWORD }}" >> $GITHUB_ENV
 
-      - name: set up Golang
-        uses: actions/setup-go@v5
-        with:
-          go-version-file: golang/vaas/go.mod
-          check-latest: true
-          cache: true
-          cache-dependency-path: golang/vaas/go.sum
       - name: run tests
         run: go test ./...
         working-directory: golang/vaas/
@@ -123,14 +118,10 @@ jobs:
 
   vulncheck:
     runs-on: ubuntu-latest
+    container:
+      image: golang:latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
-        with:
-          go-version-file: golang/vaas/go.mod
-          check-latest: true
-          cache: true
-          cache-dependency-path: golang/vaas/go.sum
       - name: Install govulncheck
         run: go install golang.org/x/vuln/cmd/govulncheck@latest
         shell: bash

--- a/golang/vaas/README.md
+++ b/golang/vaas/README.md
@@ -27,9 +27,9 @@ _Verdict-as-a-Service_ (VaaS) is a service that provides a platform for scanning
 
 It gives you as a developer functions to talk to G DATA VaaS. It wraps away the complexity of the API into basic functions.
 
-### Connect(ctx context.Context, auth authenticator.Authenticator) (termChan <-chan error, err error)
+### Connect(ctx context.Context, auth authenticator.Authenticator) (errorChan <-chan error, err error)
 
-Connect opens a websocket connection to the VAAS Server, which is kept open until the context.Context expires. The termChan indicates when a connection was closed. In the case of an unexpected close, an error is written to the channel.
+Connect opens a websocket connection to the VAAS Server. Use Close() to terminate the connection. The errorChan indicates when a connection was closed. In the case of an unexpected close, an error is written to the channel.
 
 ### ForSha256(ctx context.Context, sha256 string) (messages.VaasVerdict, error)
 
@@ -104,10 +104,11 @@ vaasClient := vaas.NewWithDefaultEndpoint(options.VaasOptions{
 ctx, webSocketCancel := context.WithCancel(context.Background())
 
 // Establish a WebSocket connection to the VaaS server
-termChan, err := vaasClient.Connect(ctx, auth)
+errorChan, err := vaasClient.Connect(ctx, auth)
 if err != nil {
       log.Fatalf("failed to connect to VaaS %s", err.Error())
 }
+defer vaasClient.Close()
 
 // Create a context with a timeout for the analysis
 analysisCtx, analysisCancel := context.WithTimeout(context.Background(), 20*time.Second)


### PR DESCRIPTION
Right now it is not possible to cancel the socket initialization because the context that is passed via `Connect()` is also used for closing the socket. It is more idiomatic in golang to let the `VaaS` client implement the `io.Closer` interface and use that to close the connection explicitly.