### PR TITLE
Update Pythons scan function comments with return dict details

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -20,6 +20,26 @@ If you want to request if a file behind a URL is safe, you can specify the URL a
 
 You can also ask for a file itself. You will still get the benefit of a fast verdict via Sha256 because the SDK will do that for you first. But additionally, if we don't know the file, the file will get uploaded and (automatically) analyzed by us.
 
+## What do the Verdicts look like
+
+The verdicts are simple. They are either
+- `Clean`: The scanners didn't find anything malicious.
+- `Malicious`: The scanners found something malicious.
+- `Unknown`: We don't know the file hash yet. A scan is then performed for each except `for_sha256` function.
+- `Pup`: Potentially Unwanted Program (Adware, Spyware, etc.)
+
+The scan functions will return the following dict:
+```python
+{
+    "Sha256": "<Sha256>",
+    "Guid": "<Guid>",
+    "Verdict": <"Clean"|"Malicious"|"Unknown"|"Pup">,
+    "Detection": "<Name of the detected malware>",
+    "FileType": "<FileType>",
+    "MimeType": "<MimeType>"
+}
+```
+
 ## How to use
 
 ### Installation

--- a/python/examples/VaasExample/main.py
+++ b/python/examples/VaasExample/main.py
@@ -25,6 +25,16 @@ async def main():
         verdict = await vaas.for_file(path)
         print(f"{verdict['Sha256']} is detected as {verdict['Verdict']}")
 
+        # The scan functions will return the following dict:
+        # {
+        #     "Sha256": "<Sha256>",
+        #     "Guid": "<Guid>",
+        #     "Verdict": <"Clean"|"Malicious"|"Unknown"|"Pup">,
+        #     "Detection": "<Name of the detected malware if found>",
+        #     "FileType": "<FileType>",
+        #     "MimeType": "<MimeType>"
+        # }
+
 
 if __name__ == "__main__":
     loop = asyncio.new_event_loop()

--- a/python/examples/VaasExample/main_url.py
+++ b/python/examples/VaasExample/main_url.py
@@ -23,6 +23,16 @@ async def main():
         verdict = await vaas.for_url(url)
         print(f"Url {url} is detected as {verdict['Verdict']}")
 
+        # The scan functions will return the following dict:
+        # {
+        #     "Sha256": "<Sha256>",
+        #     "Guid": "<Guid>",
+        #     "Verdict": <"Clean"|"Malicious"|"Unknown"|"Pup">,
+        #     "Detection": "<Name of the detected malware if found>",
+        #     "FileType": "<FileType>",
+        #     "MimeType": "<MimeType>"
+        # }
+
 
 if __name__ == "__main__":
     loop = asyncio.new_event_loop()


### PR DESCRIPTION
Since the Python SDK does not have enums like the other SDKs, I have added a short description in the Python Readme.md, as well as a short example in the respective examples.