### PR TITLE
Ruby: Overall maintenance, disable HTTP/2

### DIFF
--- a/ruby/lib/vaas/vaas_main.rb
+++ b/ruby/lib/vaas/vaas_main.rb
@@ -166,8 +166,8 @@ module VAAS
         task.with_timeout(@timeout) do
           token = message['upload_token']
           url = message['url']
-
-          client = Async::HTTP::Internet.new
+          endpoint = Async::HTTP::Endpoint.parse(url)
+          client = Async::HTTP::Client.new(endpoint, protocol: Async::HTTP::Protocol::HTTP1)
 
           header = [['authorization', token]]
           body = Protocol::HTTP::Body::File.open(File.join(path))

--- a/ruby/test/vaas_test.rb
+++ b/ruby/test/vaas_test.rb
@@ -82,7 +82,7 @@ class VaasTest < Minitest::Test
           assert_equal "Malicious", verdict
           # Detection may not be always present
           unless detection.empty?
-            assert_equal "EICAR-Test-File", detection
+            assert_match /EICAR-Test-File/, detection
           end
           vaas.close
         end

--- a/ruby/vaas.gemspec
+++ b/ruby/vaas.gemspec
@@ -15,9 +15,9 @@ Gem::Specification.new do |s|
   s.metadata = { "documentation_uri" => "https://github.com/GDATASoftwareAG/vaas/blob/main/ruby/README.md" }
   s.required_ruby_version = '>= 3.1.1'
 
-  s.add_dependency 'async', '~> 2.3.1'
-  s.add_dependency 'async-http', '~> 0.59.4'
-  s.add_dependency 'async-websocket', '~> 0.22.1'
+  s.add_dependency 'async', '~> 2.15.3'
+  s.add_dependency 'async-http', '~> 0.70.0'
+  s.add_dependency 'async-websocket', '~> 0.28.0'
 
   s.add_development_dependency "minitest", '~> 5.17.0'
   s.add_development_dependency 'dotenv', '~> 2.8.1'


### PR DESCRIPTION
Upgrade some outdated dependencies, fix changed detection names, disable HTTP/2.

Part of #558 