### PR TITLE
cpp: Enforce HTTP/1.1 in all requests (disable HTTP/2)

### DIFF
--- a/cpp/vaas.h
+++ b/cpp/vaas.h
@@ -76,6 +76,7 @@ static long getServerResponse(CURL* curl, Json::Value& jsonResponse) {
     std::string response;
     ensureCurlOk(curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, vaas_internals::writeAppendToString));
     ensureCurlOk(curl_easy_setopt(curl, CURLOPT_WRITEDATA, &response));
+    ensureCurlOk(curl_easy_setopt(curl, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_1_1));
 
     ensureCurlOk(curl_easy_perform(curl));
 


### PR DESCRIPTION
Forgot our beta SDK, let's do this here also