### PR TITLE
Fix stuck vaas request if websocket terminated

### DIFF
--- a/golang/vaas/pkg/vaas/web_socket_mock_test.go
+++ b/golang/vaas/pkg/vaas/web_socket_mock_test.go
@@ -1,0 +1,48 @@
+package vaas
+
+import "time"
+
+var _ websocketConnection = (*mockWebSocket)(nil)
+
+type mockWebSocket struct {
+	closeFunc            func() error
+	readJSONFunc         func(data any) error
+	writeJSONFunc        func(data any) error
+	setWriteDeadlineFunc func(add time.Time) error
+	writeMessageFunc     func(messageType int, data []byte) error
+}
+
+func (m mockWebSocket) Close() error {
+	if m.closeFunc != nil {
+		return m.closeFunc()
+	}
+	return nil
+}
+
+func (m mockWebSocket) ReadJSON(data any) error {
+	if m.readJSONFunc != nil {
+		return m.readJSONFunc(data)
+	}
+	return nil
+}
+
+func (m mockWebSocket) WriteJSON(data any) error {
+	if m.writeJSONFunc != nil {
+		return m.writeJSONFunc(data)
+	}
+	return nil
+}
+
+func (m mockWebSocket) SetWriteDeadline(add time.Time) error {
+	if m.setWriteDeadlineFunc != nil {
+		return m.setWriteDeadlineFunc(add)
+	}
+	return nil
+}
+
+func (m mockWebSocket) WriteMessage(messageType int, data []byte) error {
+	if m.writeMessageFunc != nil {
+		return m.writeMessageFunc(messageType, data)
+	}
+	return nil
+}

--- a/golang/vaas/v2/pkg/vaas/web_socket_mock_test.go
+++ b/golang/vaas/v2/pkg/vaas/web_socket_mock_test.go
@@ -1,0 +1,48 @@
+package vaas
+
+import "time"
+
+var _ websocketConnection = (*mockWebSocket)(nil)
+
+type mockWebSocket struct {
+	closeFunc            func() error
+	readJSONFunc         func(data any) error
+	writeJSONFunc        func(data any) error
+	setWriteDeadlineFunc func(add time.Time) error
+	writeMessageFunc     func(messageType int, data []byte) error
+}
+
+func (m mockWebSocket) Close() error {
+	if m.closeFunc != nil {
+		return m.closeFunc()
+	}
+	return nil
+}
+
+func (m mockWebSocket) ReadJSON(data any) error {
+	if m.readJSONFunc != nil {
+		return m.readJSONFunc(data)
+	}
+	return nil
+}
+
+func (m mockWebSocket) WriteJSON(data any) error {
+	if m.writeJSONFunc != nil {
+		return m.writeJSONFunc(data)
+	}
+	return nil
+}
+
+func (m mockWebSocket) SetWriteDeadline(add time.Time) error {
+	if m.setWriteDeadlineFunc != nil {
+		return m.setWriteDeadlineFunc(add)
+	}
+	return nil
+}
+
+func (m mockWebSocket) WriteMessage(messageType int, data []byte) error {
+	if m.writeMessageFunc != nil {
+		return m.writeMessageFunc(messageType, data)
+	}
+	return nil
+}


### PR DESCRIPTION
Currently when WebSocket request fails the `sendRequest()` go routine terminates without consequences and the request itself will never be closed. 