### PR TITLE
rust: Refactor uploading

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -30,4 +30,5 @@ tokio-stream = "0.1.15"
 
 [dev-dependencies]
 dotenv = "0.15"
+tempfile = "3.12.0"
 tokio = { version = "1.37", features = ["rt", "macros", "rt-multi-thread"] }

--- a/rust/tests/real_api_integration_tests.rs
+++ b/rust/tests/real_api_integration_tests.rs
@@ -645,3 +645,12 @@ async fn from_url_multiple_url() {
     );
     assert_eq!(Verdict::Clean, verdict[2].as_ref().unwrap().verdict);
 }
+
+#[tokio::test]
+async fn for_buf() {
+    let vaas = get_vaas_with_flags(false, false).await;
+    let ct = CancellationToken::from_seconds(10);
+    let data = vec![];
+    let result = vaas.for_buf(data, &ct).await.unwrap();
+    assert_eq!(result.verdict, Verdict::Clean);
+}

--- a/rust/tests/real_api_integration_tests.rs
+++ b/rust/tests/real_api_integration_tests.rs
@@ -650,7 +650,7 @@ async fn from_url_multiple_url() {
 async fn for_buf() {
     let vaas = get_vaas_with_flags(false, false).await;
     let ct = CancellationToken::from_seconds(10);
-    let data = vec![];
+    let data = vec![1,2,3,4];
     let result = vaas.for_buf(data, &ct).await.unwrap();
     assert_eq!(result.verdict, Verdict::Clean);
 }


### PR DESCRIPTION
* Reorder some functions for better reading flow
* Generalize for_file: Allow any type that implements a new interface "UploadData". Add a new internal function for_generic that uses UploadData-types. for_file simply forwards to for_generic, as &Path implements UploadData
* Add a new function for_buf, whose buffer also implements UploadData and hence also uses for_generic internally
    * Adding support for new data types is now trivial
* Refactor SHA256 computation a bit, improve performance (more fixes coming here)
* for_stream still needs special handling, as it can't locally compute the SHA256.