### PR TITLE
fix: don't create a new WebsocketClient object reference for every connection delay tick

### DIFF
--- a/java/src/main/java/de/gdata/vaas/Vaas.java
+++ b/java/src/main/java/de/gdata/vaas/Vaas.java
@@ -69,8 +69,8 @@ public class Vaas implements AutoCloseable {
     public void connect() throws IOException, InterruptedException, VaasAuthenticationException, TimeoutException {
         var timer = new SimpleTimer(connectionTimeoutInMs, TimeUnit.MILLISECONDS);
         var clientToken = authenticator.getToken();
+        this.client = new WebSocketClient(this.getConfig(), clientToken);
         while (true) {
-            this.client = new WebSocketClient(this.getConfig(), clientToken);
             if (this.client.connectBlocking(timer.getRemainingMs(), TimeUnit.MILLISECONDS)) {
                 try {
                     this.client.Authenticate(timer.getRemainingMs(), TimeUnit.MILLISECONDS);


### PR DESCRIPTION
Initialize WebSocketClient only once to prevent redundant re-creation during connection retries, addressing potential issues with garbage collection when OS-level blocking operations may prevent proper cleanup, leading to excessive thread accumulation.